### PR TITLE
Make terminology consistent

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,7 +204,7 @@ function App() {
   function RetireAmountInput() {
     return (
       <div>
-        <p className="input-title">AMOUNT IN CARBON TONS</p>
+        <p className="input-title">AMOUNT IN CARBON TONNES</p>
         <input
           onKeyDown={(evt) =>
             ["e", "E", "+", "-"].includes(evt.key) && evt.preventDefault()
@@ -242,7 +242,7 @@ function App() {
           }}
           id="amount"
           type="number"
-          placeholder="How many carbon tons would you like to retire?"
+          placeholder="How many carbon tonnes would you like to retire?"
         />
         <button
           onClick={() => {
@@ -333,7 +333,7 @@ function App() {
       <button onClick={() => action()} className="burn">
         {active
           ? currentCoinApproved()
-            ? "BURN"
+            ? "RETIRE"
             : "APPROVE"
           : "CONNECT WALLET"}
       </button>
@@ -721,7 +721,7 @@ function App() {
               title="You've Retired"
               symbol={Leaf}
               amount={totalCarbonRetired.toFixed(3)}
-              subtitle="Tons of Carbon Retired"
+              subtitle="Tonnes of Carbon Retired"
             />
             <BreakdownCard
               carbonTypes={[

--- a/src/components/BurnModal.tsx
+++ b/src/components/BurnModal.tsx
@@ -29,7 +29,7 @@ export function BurnModal(props: { setBurnModal: (a: boolean) => void }) {
           />
         </div>
         <p id="approvingStatus" style={{ margin: "auto" }}>
-          Burning...
+          Retiring...
         </p>
       </div>
     </div>

--- a/src/components/ConversionPanel.tsx
+++ b/src/components/ConversionPanel.tsx
@@ -37,7 +37,7 @@ export function ConversionPanel(props: {
     <div>
       <div className="seperate">
         <p className="input-title">COST</p>
-        <p className="input-title">BURNING</p>
+        <p className="input-title">RETIRING</p>
       </div>
       <div style={{ display: "flex", justifyContent: "space-between" }}>
         <CoinPanel


### PR DESCRIPTION
"tons" and "tonnes" are diff units - we measure CO2 in tonnes

also removed all uses of "burn" in the displayed text in favor of "retire"